### PR TITLE
proposition: state orchestrator

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -14,7 +14,7 @@ const mockProject: Project = {
     },
     materialIds: [],
     conversations: [],
-    quizes: []
+    quizzes: []
 };
 
 export default function Home() {

--- a/src/contexts/course-mode/application/use-cases/start-project-conversation.ts
+++ b/src/contexts/course-mode/application/use-cases/start-project-conversation.ts
@@ -38,6 +38,7 @@ function generateProjectConversation(
     const firstMessage = generateFirstMessage(project);
     return {
         id: uuidv4(),
+        title: 'New conversation',
         messages: [firstMessage],
         mode: mode
     };

--- a/src/shared/application/ports/out/cache-provider.ts
+++ b/src/shared/application/ports/out/cache-provider.ts
@@ -1,0 +1,4 @@
+export interface CacheProvider<T> {
+    push(obj: T): Promise<void>
+    get(id: string): Promise<T | null>
+}

--- a/src/shared/application/ports/out/oubox-provider.ts
+++ b/src/shared/application/ports/out/oubox-provider.ts
@@ -1,0 +1,6 @@
+import { DomainEvent } from '@/shared/entities/domain-event';
+
+export interface OutboxProvider {
+    enqueueWorkItem(event: DomainEvent): Promise<void>;
+    registerWorker(): void;
+}

--- a/src/shared/application/services/observable-message-orchestration-service.ts
+++ b/src/shared/application/services/observable-message-orchestration-service.ts
@@ -1,0 +1,81 @@
+import { ProjectRepo } from '@/contexts/course-mode/application/ports/out/project-repo';
+import { MaterialRepo } from '@/shared/application/ports/out/material-repo';
+import { VectorRepo } from '@/shared/ports/out/vector-repo';
+import {
+    DomainEvent,
+    DomainEventType,
+    MaterialUploadedEvent,
+    ProjectCreatedEvent
+} from '@/shared/entities/domain-event';
+import { projectToUi, UiProject } from '@/shared/entities/project';
+import { OutboxProvider } from '../ports/out/oubox-provider';
+import { CacheProvider } from '@/shared/application/ports/out/cache-provider';
+import { UiMaterial } from '@/shared/entities/material';
+
+export interface AppState {
+    userId: string;
+    projects: UiProject[];
+    materials: UiMaterial[];
+}
+
+export type OMOSListener = () => void;
+
+export class ObservableMessageOrchestrationService {
+    private listeners = new Set<OMOSListener>();
+    private handlers: Map<DomainEventType, (event: DomainEvent, state: AppState) => Promise<void>>;
+
+    constructor(
+        private projectRepo: ProjectRepo,
+        private materialRepo: MaterialRepo,
+        private vectorRepo: VectorRepo,
+        // stores warm state for currently active users
+        private cachedStateProvider: CacheProvider<AppState>,
+        // enqueue tasks for workers
+        private outbox: OutboxProvider,
+    ) {
+        this.handlers = new Map([
+            [DomainEventType.PROJECT_CREATED, this.handleProjectCreated],
+            [DomainEventType.MATERIAL_UPLOADED, this.handleMaterialUploaded],
+        ]);
+    }
+
+    async pushEvent(event: DomainEvent) {
+        // update cached state quickly, push heavy tasks to outbox
+        const state = await this.getCachedUserState(event.payload.userId);
+
+        const handler = this.handlers.get(event.type);
+        if (handler) {
+            await handler(event, state);
+        } else {
+            throw new Error(`No handler registered for event type: ${event.type}`);
+        }
+
+        await this.cachedStateProvider.push(state);
+        await this.outbox.enqueueWorkItem(event);
+        this.emit();
+    }
+
+    subscribe = (listener: OMOSListener) => {
+        this.listeners.add(listener);
+        return () => this.listeners.delete(listener);
+    };
+
+    emit() {
+        for (const l of this.listeners) l();
+    }
+
+    private async getCachedUserState(userId: string) {
+        return await this.cachedStateProvider.get(userId)
+            ?? { userId, projects: [], materials: [] };
+    }
+
+    private handleProjectCreated = async (event: DomainEvent, state: AppState)=> {
+        const project = (event as ProjectCreatedEvent).payload.project;
+        state.projects.push(projectToUi(project));
+    }
+
+    private handleMaterialUploaded = async (event: DomainEvent, state: AppState) => {
+        const material = (event as MaterialUploadedEvent).payload.material;
+        state.materials.push(material);
+    }
+}

--- a/src/shared/entities/conversation.ts
+++ b/src/shared/entities/conversation.ts
@@ -2,7 +2,14 @@ import { Message } from '../application/ports/out/llm-provider';
 
 export interface Conversation {
     id: string;
+    title: string;
     messages: Message[];
+    mode: Mode;
+}
+
+export interface UiConversation {
+    id: string;
+    title: string;
     mode: Mode;
 }
 

--- a/src/shared/entities/domain-event.ts
+++ b/src/shared/entities/domain-event.ts
@@ -1,0 +1,19 @@
+import { Project } from '@/shared/entities/project';
+import { Material } from '@/shared/entities/material';
+
+export enum DomainEventType {
+    PROJECT_CREATED = 'PROJECT_CREATED',
+    MATERIAL_UPLOADED = 'MATERIAL_UPLOADED',
+}
+
+export type ProjectCreatedEvent = {
+    type: DomainEventType.PROJECT_CREATED;
+    payload: { userId: string; project: Project };
+};
+
+export type MaterialUploadedEvent = {
+    type: DomainEventType.MATERIAL_UPLOADED;
+    payload: { userId: string; material: Material };
+};
+
+export type DomainEvent = ProjectCreatedEvent | MaterialUploadedEvent;

--- a/src/shared/entities/material.ts
+++ b/src/shared/entities/material.ts
@@ -6,3 +6,8 @@ export interface Material {
     title: string;
     content: ParsedContent;
 }
+
+export interface UiMaterial {
+    id: string;
+    title: string;
+}

--- a/src/shared/entities/project.ts
+++ b/src/shared/entities/project.ts
@@ -1,6 +1,7 @@
 import { LearningRoadmap } from '@/contexts/course-mode/entities/learning-roadmap';
 import { Quiz } from '@/contexts/quiz-mode/entities/quiz';
-import { Conversation } from '@/shared/entities/conversation';
+import { Conversation, UiConversation } from '@/shared/entities/conversation';
+import { UiMaterial } from '@/shared/entities/material';
 
 export interface Project {
     id: string;
@@ -8,5 +9,25 @@ export interface Project {
     materialIds: string[];
     roadmap: LearningRoadmap;
     conversations: Conversation[];
-    quizes: Quiz[];
+    quizzes: Quiz[];
+}
+
+export interface UiProject {
+    id: string;
+    title: string;
+    materialIds: string[];
+    roadmapId: string;
+    conversationIds: string[];
+    quizIds: string[];
+}
+
+export function projectToUi(p: Project): UiProject {
+    return {
+        id: p.id,
+        title: p.title,
+        materialIds: p.materialIds,
+        roadmapId: p.roadmap.id,
+        conversationIds: p.conversations.map(c => c.id),
+        quizIds: p.quizzes.map(q => q.id),
+    }
 }

--- a/src/shared/interface/controllers/stateful-controller.ts
+++ b/src/shared/interface/controllers/stateful-controller.ts
@@ -1,0 +1,25 @@
+export type StateListener = () => void;
+
+export abstract class StatefulController<T extends object> {
+    private listeners = new Set<StateListener>();
+    protected state: T | null = null;
+
+    getState(): T | null {
+        return this.state;
+    }
+
+    subscribe = (listener: StateListener) => {
+        this.listeners.add(listener);
+        return () => this.listeners.delete(listener);
+    };
+
+    getSnapshot = (): T | null => {
+        return this.getState();
+    };
+
+    protected emit() {
+        for (const l of this.listeners) {
+            l();
+        }
+    }
+}

--- a/src/shared/interface/controllers/storage-controller.ts
+++ b/src/shared/interface/controllers/storage-controller.ts
@@ -1,0 +1,9 @@
+import { StatefulController } from '@/shared/interface/controllers/stateful-controller';
+import { UiProject } from '@/shared/entities/project';
+import { ProjectRepo } from '@/contexts/course-mode/application/ports/out/project-repo';
+import { MaterialRepo } from '@/shared/application/ports/out/material-repo';
+import { VectorRepo } from '@/shared/ports/out/vector-repo';
+
+export class StorageController extends StatefulController<AppState> {
+
+}


### PR DESCRIPTION
my proposed overengineered flow: 
1. use cases emit events to the orchestrator
2. events quickly update cached state 
3. and then dispatch to worker via outbox
4. worker pulls from the scratchpad (outbox) - this could be a queue, db, or a file for now.
5. worker processes the event async (could be something like lambda in the future i guess) 
6. while worker does it's thing we have already notified observers of the orchestrator about the update in state. this in turn updates the internal state of client-side controllers, which refreshes the UI (via syncExternalRepo)

wdyt? i don't want to go into this further without discussing. 
right now i'm still pretty confused about what's executed in UI vs server but i think we can make this work